### PR TITLE
Get prices.

### DIFF
--- a/bjsparserlib/database.py
+++ b/bjsparserlib/database.py
@@ -105,12 +105,12 @@ def _insert_inventory(cursor, inventory):
             print("No category information for {}".format(item["name"]))
             continue
 
-        cursor.execute("INSERT INTO products (name, categoryid, url, store, stocked) VALUES (?, ?, ?, ?, ?)", (item["name"], category_id, item["url"], store, None))
+        cursor.execute("INSERT INTO products (name, price, categoryid, url, store, stocked) VALUES (?, ?, ?, ?, ?, ?)", (item["name"], json.dumps(item["price"]), category_id, item["url"], store, None))
 
 def _create_tables(cursor):
     cursor.execute("PRAGMA foreign_keys = ON")
     cursor.execute("CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, store TEXT, parentid INTEGER, FOREIGN KEY(parentid) REFERENCES categories(id))")
-    cursor.execute("CREATE TABLE IF NOT EXISTS products (name, categoryid, url, store, stocked)")
+    cursor.execute("CREATE TABLE IF NOT EXISTS products (name, price, categoryid, url, store, stocked)")
 
 def _db_connect(database_filepath):
     connection = sqlite3.connect(database_filepath)


### PR DESCRIPTION
This proved to be messier than expected. The short version is that this
is put into the inventory DB as a JSON blob. Two numbers means the price
is a range; otherwise it's a simple price.

More details: The API has a few fields for price, and none of them are
simply "Here's the price to display." Instead, the displayPrice,
listprice, and product_price all are the same "base" price. However, BJs
often sells items for different prices at different stores. The API also
has a list of prices by store ID, along with a bunch of other info,
which greatly bloats the response and slows response time. There is a
condensed field which allows easy mapping store ID to price.
Unfortunately, it requires processing, as it's a semi-colon separated
string in a specific setup, but it's the best option.

Additionally, some items have a price range. This seems to occur when an
item has multiple variants (e.g. sizes). The underlying data is a bit
odd, in that some of these variants don't have the club to price
mapping, forcing us to fall back to displayPrice (in those instances
only).

That the price is ocassionally a range means we must always treat it as
a range. For storage in the database, the min and max price are dumped
as a JSON list into a TEXT column.